### PR TITLE
Add a "swap_df0_with_dfX" option in cmdline.txt

### DIFF
--- a/src/aarch64/start.c
+++ b/src/aarch64/start.c
@@ -1567,7 +1567,6 @@ void M68K_StartEmu(void *addr, void *fdt)
             if (strstr(prop->op_value, "enable_d0_slow"))
                 mmu_map(0xd00000, 0xd00000, 524288, MMU_ACCESS | MMU_ISHARE | MMU_ALLOW_EL0 | MMU_ATTR(0), 0);
 
-
             extern int disasm;
             extern int debug;
             extern int DisableFPU;
@@ -1580,6 +1579,17 @@ void M68K_StartEmu(void *addr, void *fdt)
 
             if (strstr(prop->op_value, "disassemble"))
                 disasm = 1;
+
+#ifdef PISTORM
+            extern uint32_t swap_df0_with_dfx;
+
+            if (strstr(prop->op_value, "swap_df0_with_df1"))
+                swap_df0_with_dfx = 1;
+            if (strstr(prop->op_value, "swap_df0_with_df2"))
+                swap_df0_with_dfx = 2;
+            if (strstr(prop->op_value, "swap_df0_with_df3"))
+                swap_df0_with_dfx = 3;
+#endif
         }       
     }
 

--- a/src/aarch64/vectors.c
+++ b/src/aarch64/vectors.c
@@ -280,6 +280,16 @@ uint32_t overlay = 1;
 uint32_t z2_ram_autoconf = 1;
 uint64_t z2_ram_base = 0;
 
+uint32_t swap_df0_with_dfx = 0;
+uint32_t spoof_df0_id = 0;
+
+// Amiga specific registers
+enum
+{
+    CIAAPRA = 0xBFE001,
+    CIABPRB = 0xBFD100,
+};
+
 int SYSWriteValToAddr(uint64_t value, int size, uint64_t far)
 {
     D(kprintf("[JIT:SYS] SYSWriteValToAddr(0x%x, %d, %p)\n", value, size, far));
@@ -301,10 +311,29 @@ int SYSWriteValToAddr(uint64_t value, int size, uint64_t far)
         kprintf("Z3 write access with far %08x\n", far);
     }
 
-    if (far == 0xBFE001 && size == 1) {
+    if (far == CIAAPRA && size == 1) {
         if ((value & 1) != overlay) {
             kprintf("[JIT:SYS] OVL bit changing to %d\n", value & 1);
             overlay = value & 1;
+        }
+    }
+
+    if (far == CIABPRB) {
+        if (swap_df0_with_dfx) {
+            const int SEL0_BITNUM = 3;
+
+            if ((value & ((1 << (SEL0_BITNUM + swap_df0_with_dfx)) | 0x80)) == 0x80) {
+              // If drive selected but motor off, Amiga is reading drive ID.
+              spoof_df0_id = 1;
+            } else {
+              spoof_df0_id = 0;
+            }
+
+            // If the value for SEL0/SELx differ
+            if (((value >> SEL0_BITNUM) & 1) != ((value >> (SEL0_BITNUM + swap_df0_with_dfx)) & 1)) {
+              // Invert both bits to swap them around
+              value ^= ((1 << SEL0_BITNUM) | (1 << (SEL0_BITNUM + swap_df0_with_dfx)));
+            }
         }
     }
 
@@ -428,6 +457,27 @@ int SYSReadValFromAddr(uint64_t *value, int size, uint64_t far)
             b = ps_read_32(far + 4);
             *value = (a << 32) | b;
             break;
+    }
+
+    if (far == CIAAPRA) {
+        if (swap_df0_with_dfx && spoof_df0_id) {
+            // DF0 doesn't emit a drive type ID on RDY pin
+            // If swapping DF0 with DF1-3 we need to provide this ID so that DF0 continues to function.
+            *value = (*value & 0xDF); // Spoof drive id for swapped DF0 by setting RDY low
+        }
+    }
+
+    if (far == CIABPRB) {
+        if (swap_df0_with_dfx) {
+            const int SEL0_BITNUM = 3;
+
+            // SEL0 = 0x80, SEL1 = 0x10, SEL2 = 0x20, SEL3 = 0x40
+            // If the value for SEL0/SELx differ
+            if (((*value >> SEL0_BITNUM) & 1) != ((*value >> (SEL0_BITNUM + swap_df0_with_dfx)) & 1)) {
+              // Invert both bits to swap them around
+              *value ^= ((1 << SEL0_BITNUM) | (1 << (SEL0_BITNUM + swap_df0_with_dfx)));
+            }
+        }
     }
 
     return 1;


### PR DESCRIPTION
This mirrors an option available in the Linux pistorm version, and allows the Amiga disk drive 0 to be swapped with any other
connected external drive. This is particularly useful on systems with external GoTek drives.

eg:
- "swap_df0_with_df1"
- "swap_df0_with_df2"
- "swap_df0_with_df3"