### PR TITLE
Add "move_slow_to_chip" option to cmdline.txt

### DIFF
--- a/src/aarch64/start.c
+++ b/src/aarch64/start.c
@@ -1582,6 +1582,7 @@ void M68K_StartEmu(void *addr, void *fdt)
 
 #ifdef PISTORM
             extern uint32_t swap_df0_with_dfx;
+            extern uint32_t move_slow_to_chip;
 
             if (strstr(prop->op_value, "swap_df0_with_df1"))
                 swap_df0_with_dfx = 1;
@@ -1589,6 +1590,9 @@ void M68K_StartEmu(void *addr, void *fdt)
                 swap_df0_with_dfx = 2;
             if (strstr(prop->op_value, "swap_df0_with_df3"))
                 swap_df0_with_dfx = 3;
+
+            if (strstr(prop->op_value, "move_slow_to_chip"))
+                move_slow_to_chip = 1;
 #endif
         }       
     }

--- a/src/aarch64/vectors.c
+++ b/src/aarch64/vectors.c
@@ -283,6 +283,8 @@ uint64_t z2_ram_base = 0;
 uint32_t swap_df0_with_dfx = 0;
 uint32_t spoof_df0_id = 0;
 
+uint32_t move_slow_to_chip = 0;
+
 // Amiga specific registers
 enum
 {
@@ -363,6 +365,17 @@ int SYSWriteValToAddr(uint64_t value, int size, uint64_t far)
         return 1;
     }
 
+    if (move_slow_to_chip) {
+        if (far >= 0x080000 && far <= 0x0FFFFF) {
+            // A500 JP2 connects Agnus' A19 input to A23 instead of A19 by default, and decodes trapdoor memory at 0xC00000 instead of 0x080000.
+            // We can move the trapdoor to chipram simply by rewriting the address.
+            far += 0xB80000;
+        } else if (far >= 0xC00000 && far <= 0xC7FFFF) {
+            // Block accesses through to trapdoor at slow ram address, otherwise it will be detected at 0x080000 and 0xC00000.
+            return 1;
+        }
+    }
+
     switch(size)
     {
         case 1:
@@ -437,6 +450,18 @@ int SYSReadValFromAddr(uint64_t *value, int size, uint64_t far)
                     break;
             }
 
+            return 1;
+        }
+    }
+
+    if (move_slow_to_chip) {
+        if (far >= 0x080000 && far <= 0x0FFFFF) {
+            // A500 JP2 connects Agnus' A19 input to A23 instead of A19 by default, and decodes trapdoor memory at 0xC00000 instead of 0x080000.
+            // We can move the trapdoor to chipram simply by rewriting the address.
+            far += 0xB80000;
+        } else if (far >= 0xC00000 && far <= 0xC7FFFF) {
+            // Block accesses through to trapdoor at slow ram address, otherwise it will be detected at 0x080000 and 0xC00000.
+            *value = 0;
             return 1;
         }
     }


### PR DESCRIPTION
This option allows Amiga 500s with an upgraded Fat Agnus 8372 and a 512k memory expansion to be able to use 1MB of chip ram memory without making any hardware modification on the motherboard.

Tested working successfully on my A500 with a 8372 and 512kb expansion.