### PR TITLE
MDIO pins setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ build*/
 Build*/
 !build-scripts/
 
+# Install directory
+install/
+
 # Prerequisites
 *.d
 

--- a/src/pistorm/ps32_protocol.c
+++ b/src/pistorm/ps32_protocol.c
@@ -117,7 +117,11 @@ typedef unsigned int uint;
 #define PIN_A(x)        (24 + x)
 #define SER_OUT_CLK     27 //debug EMU68
 
-#define CLEAR_BITS      (0x0fffffff & ~((1 << PIN_RD) | (1 << PIN_WR) | (1 << SER_OUT_BIT) | (1 << SER_OUT_CLK)))
+// Pins for MDIO
+#define PIN_RGMII_MDIO  28
+#define PIN_RGMII_MDC   29
+
+#define CLEAR_BITS      (0x0fffffff & ~((1 << PIN_RD) | (1 << PIN_WR) | (1 << SER_OUT_BIT) | (1 << SER_OUT_CLK) | (1 << PIN_RGMII_MDIO) | (1 << PIN_RGMII_MDC)))
 
 // Pins for FPGA programming
 #define PIN_CRESET1     6
@@ -142,11 +146,11 @@ typedef unsigned int uint;
 
 #define GPFSEL0_INPUT (GO(PIN_WR) | GO(PIN_RD) | GO(SER_OUT_BIT))
 #define GPFSEL1_INPUT (0)
-#define GPFSEL2_INPUT (GO(29) | GO(PIN_A(2)) | GO(PIN_A(1)) | GO(PIN_A(0)) | GO(SER_OUT_CLK))
+#define GPFSEL2_INPUT (GO(PIN_A(2)) | GO(PIN_A(1)) | GO(PIN_A(0)) | GO(SER_OUT_CLK) | PF(AF5, PIN_RGMII_MDC) | PF(AF5, PIN_RGMII_MDIO))
 
 #define GPFSEL0_OUTPUT (GO(PIN_D(1)) | GO(PIN_D(0)) | GO(PIN_WR) | GO(PIN_RD) | GO(SER_OUT_BIT))
 #define GPFSEL1_OUTPUT (GO(PIN_D(11)) | GO(PIN_D(10)) | GO(PIN_D(9)) | GO(PIN_D(8)) | GO(PIN_D(7)) | GO(PIN_D(6)) | GO(PIN_D(5)) | GO(PIN_D(4)) | GO(PIN_D(3)) | GO(PIN_D(2)))
-#define GPFSEL2_OUTPUT (GO(29) | GO(PIN_A(2)) | GO(PIN_A(1)) | GO(PIN_A(0)) | GO(PIN_D(15)) | GO(PIN_D(14)) | GO(PIN_D(13)) | GO(PIN_D(12)) | GO(SER_OUT_CLK))
+#define GPFSEL2_OUTPUT (GO(PIN_A(2)) | GO(PIN_A(1)) | GO(PIN_A(0)) | GO(PIN_D(15)) | GO(PIN_D(14)) | GO(PIN_D(13)) | GO(PIN_D(12)) | GO(SER_OUT_CLK) | PF(AF5, PIN_RGMII_MDC) | PF(AF5, PIN_RGMII_MDIO))
 
 #define REG_DATA_LO     0
 #define REG_DATA_HI     1


### PR DESCRIPTION
This is to enable development of a genet driver.
Genet has got MDIO wired at GPIO pins 28 and 29, these need to be set to alternate function 5 in order to communicate with the PHY.
As it happens this is controlled by GPFSEL2, which gets happily overwritten by pistorm protocol handling.

With this patch, I'm able to initialize UMAC, PHY and then send and receive frames.