### PR TITLE
genet requires GPIO 28&29 set to AF5, not AF1

### DIFF
--- a/src/pistorm/ps_protocol.h
+++ b/src/pistorm/ps_protocol.h
@@ -76,11 +76,11 @@
 
 #define GPFSEL0_INPUT_PI4 0x00244240
 #define GPFSEL1_INPUT_PI4 0x00000000
-#define GPFSEL2_INPUT_PI4 (0x00000000 | (1 << 18) | (1 << 21) | (5 << 27) | (5 << 24))
+#define GPFSEL2_INPUT_PI4 (0x00000000 | (1 << 18) | (1 << 21) | (2 << 27) | (2 << 24))
 
 #define GPFSEL0_OUTPUT_PI4 0x09244240
 #define GPFSEL1_OUTPUT_PI4 0x09249249
-#define GPFSEL2_OUTPUT_PI4 (0x00000249 | (1 << 18) | (1 << 21) | (5 << 27) | (5 << 24))
+#define GPFSEL2_OUTPUT_PI4 (0x00000249 | (1 << 18) | (1 << 21) | (2 << 27) | (2 << 24))
 
 #endif
 


### PR DESCRIPTION
Pi4 + classic pistorm.

5 = AF1
2 = AF5

https://github.com/rondoval/emu68-genet-driver/issues/6