### PR TITLE
enable early boot logging on standard serial port

### DIFF
--- a/src/aarch64/start.c
+++ b/src/aarch64/start.c
@@ -927,7 +927,7 @@ void boot(void *dtree)
     /* Setup debug console on serial port */
     setup_serial();
 
-    kprintf("\033[2J[BOOT] Booting %s\n", bootstrapName);
+    kprintf("[BOOT] Booting %s\n", bootstrapName);
     p = dt_find_property(dt_find_node("/"), "model");
     if (p) {
         kprintf("[BOOT] Machine: %s\n", p->op_value);

--- a/src/aarch64/start.c
+++ b/src/aarch64/start.c
@@ -927,7 +927,7 @@ void boot(void *dtree)
     /* Setup debug console on serial port */
     setup_serial();
 
-    kprintf("[BOOT] Booting %s\n", bootstrapName);
+    kprintf("\033[2J[BOOT] Booting %s\n", bootstrapName);
     p = dt_find_property(dt_find_node("/"), "model");
     if (p) {
         kprintf("[BOOT] Machine: %s\n", p->op_value);

--- a/src/pistorm/ps32_protocol.c
+++ b/src/pistorm/ps32_protocol.c
@@ -228,7 +228,8 @@ static inline void set_output() {
 void pistorm_setup_serial()
 {
     uint32_t fsel;
-    
+    gpio =    ((volatile uint32_t *)BCM2708_PERI_BASE) + GPIO_ADDR / 4;
+
     fsel = *(gpio + REG(SER_OUT_BIT));
     fsel &= LE32(~MASK(SER_OUT_BIT));
     fsel |= LE32(FUNC(SER_OUT_BIT, OUT));
@@ -1125,6 +1126,11 @@ void (*write_access_128)(unsigned int address, uint128_t data);
 
 void ps_setup_protocol()
 {
+    pistorm_setup_io();
+    pistorm_setup_serial();
+
+    *gpreset = LE32(CLEAR_BITS);
+
     if (use_2slot)
     {
         kprintf("[PS32] Setting up two-slot protocol\n");
@@ -1151,11 +1157,6 @@ void ps_setup_protocol()
     }
 
 //    __atomic_clear(&gpio_lock, __ATOMIC_RELEASE);
-
-    pistorm_setup_io();
-    pistorm_setup_serial();
-
-    *gpreset = LE32(CLEAR_BITS);
 
     set_input();
 }

--- a/src/pistorm/ps_protocol.h
+++ b/src/pistorm/ps_protocol.h
@@ -104,7 +104,7 @@ void ps_write_status_reg(unsigned int value);
 void ps_setup_protocol();
 void ps_reset_state_machine();
 void ps_pulse_reset();
-
+void pistorm_setup_serial();
 void bitbang_putByte(uint8_t byte);
 void fastSerial_putByte(uint8_t byte);
 void fastSerial_init();

--- a/src/raspi/support_rpi.c
+++ b/src/raspi/support_rpi.c
@@ -432,8 +432,10 @@ void setup_serial()
                 fast_serial = 1;
                 fastSerial_init();
             }
-            else
+            else {
                 fast_serial = 0;
+                pistorm_setup_serial();
+            }
         }
     }
 


### PR DESCRIPTION
The Efinix gateware loading unconfigures serial port. Proper config is restored later, resulting with loss of some log entries.