### PR TITLE
PCIe controller support

### DIFF
--- a/include/intc.h
+++ b/include/intc.h
@@ -19,6 +19,7 @@ extern "C" {
 
 int gic_available();
 void gic_local_init();
+void gic_local_disable();
 void gic_irq_eanble(unsigned int id);
 void gic_irq_disable(unsigned int id);
 void gic_set_priority(unsigned int id, uint8_t prio);

--- a/src/aarch64/intc.c
+++ b/src/aarch64/intc.c
@@ -88,6 +88,16 @@ void gic_local_init()
     kprintf("[GIC] CPU local enabled, Version %08x\n", rd32le(gic_base_cpu + GICC_IIDR));
 }
 
+void gic_local_disable()
+{
+    kprintf("[GIC] gic_local_disable()\n");
+
+    /* Disable CPU interface */
+    uint32_t reg = rd32le(gic_base_cpu + GICC_CTLR);
+    reg &= ~1;
+    wr32le(gic_base_cpu + GICC_CTLR, reg);
+}
+
 void gic_irq_eanble(unsigned int id)
 {
     uint32_t reg = id / 32;

--- a/src/aarch64/start.c
+++ b/src/aarch64/start.c
@@ -146,7 +146,7 @@ __asm__("   .section .startup           \n"
 "       ldr     x10, =" xstr(MMU_ATTR_ENTRIES) "\n"
 "       msr     MAIR_EL1, x10       \n" /* Set memory attributes */
 
-"       ldr     x10, =0xb5193519    \n" /* Upper and lower enabled, both 39bit in size */
+"       ldr     x10, =0x1b5193519   \n" /* Upper and lower enabled, both 39bit in size, 36bit IPS */
 "       msr     TCR_EL1, x10        \n"
 
 "       adrp    x10, mmu_user_L1    \n" /* Load table pointers for low and high memory regions */
@@ -385,7 +385,7 @@ __asm__(
 "       ldr     x10, =" xstr(MMU_ATTR_ENTRIES) "\n"
 "       msr     MAIR_EL1, x10       \n" /* Set memory attributes */
 
-"       ldr     x10, =0xb5193519    \n" /* Upper and lower enabled, both 39bit in size */
+"       ldr     x10, =0x1b5193519    \n" /* Upper and lower enabled, both 39bit in size, 36bit IPS */
 "       msr     TCR_EL1, x10        \n"
 
 "       adrp    x10, mmu_user_L1    \n" /* Load table pointers for low and high memory regions */

--- a/src/aarch64/vectors.c
+++ b/src/aarch64/vectors.c
@@ -369,10 +369,10 @@ int SYSWriteValToAddr(uint64_t value, uint64_t value2, int size, uint64_t far)
         else {
             INT_shadow.INTENA &= ~(value & 0x7fff);
         }
-        if (INT_shadow.ARMPending && (INT_shadow.INTENA & 0x6000) == 0x6000) {
+        if (INT_shadow.ARMPending) {
             struct M68KState *ctx;
             __asm__ volatile("mov %0, "CTX_POINTER_ASM"\n":"=r"(ctx));
-            ctx->INTF.ARM = 0x01;
+            ctx->INTF.ARM = (INT_shadow.INTENA & 0x6000) == 0x6000 ? 0x01 : 0;
         }
     }
 

--- a/src/pistorm/ps_classic_protocol.c
+++ b/src/pistorm/ps_classic_protocol.c
@@ -16,6 +16,7 @@
 #include "ps_protocol.h"
 #include "M68k.h"
 #include "cache.h"
+#include "intc.h"
 
 volatile unsigned int *gpio;
 volatile unsigned int *gpclk;
@@ -811,7 +812,13 @@ void ps_pulse_reset()
     ignore_reset = 0;
 }
 
-void ps_send_reset() { ps_pulse_reset(); }
+void ps_send_reset()
+{
+    if(gic_available())
+        gic_local_disable();
+
+    ps_pulse_reset();
+}
 
 unsigned int ps_get_ipl_zero()
 {

--- a/src/pistorm/ps_protocol.c
+++ b/src/pistorm/ps_protocol.c
@@ -16,6 +16,7 @@
 #include "ps_protocol.h"
 #include "M68k.h"
 #include "cache.h"
+#include "intc.h"
 
 extern struct M68KState *__m68k_state;
 
@@ -2000,6 +2001,31 @@ volatile int ignore_reset = 0;
 #define PM_WDOG_MAGIC 0x5a000000
 #define PM_RSTC_FULLRST 0x00000020
 
+void pi_reset()
+{
+    ps_set_control(CONTROL_REQ_BM);
+    usleep(100000);
+
+    ps_set_control(CONTROL_DRIVE_RESET);
+    usleep(150000);
+
+    unsigned int r;
+    // trigger a restart by instructing the GPU to boot from partition 0
+    r = LE32(*PM_RSTS);
+    r &= 0xfffffaaa; //bits 0,2,4,6,8,10 are boot partition
+    *PM_RSTS = LE32(PM_WDOG_MAGIC | r); // boot from partition 0
+    
+    *PM_WDOG = LE32(PM_WDOG_MAGIC | 10);
+
+    r = LE32(*PM_RSTC);
+    r &= 0xffffffcf;
+    r |= PM_WDOG_MAGIC | PM_RSTC_FULLRST;
+    *PM_RSTC = LE32(r);
+
+    while (1)
+        ;
+}
+
 void ps_pulse_reset()
 {
     ignore_reset = 1;
@@ -2093,23 +2119,7 @@ void ps_pulse_reset()
             kprintf("[PS] leaving stealth mode now\n");
 
             kprintf("[PS] Resetting RasPi now...\n");
-
-            ps_set_control(CONTROL_REQ_BM);
-            usleep(100000);
-
-            ps_set_control(CONTROL_DRIVE_RESET);
-            usleep(150000);
-
-            unsigned int r;
-            // trigger a restart by instructing the GPU to boot from partition 0
-            r = LE32(*PM_RSTS);
-            r &= ~0xfffffaaa;
-            *PM_RSTS = LE32(PM_WDOG_MAGIC | r); // boot from partition 0
-            *PM_WDOG = LE32(PM_WDOG_MAGIC | 10);
-            *PM_RSTC = LE32(PM_WDOG_MAGIC | PM_RSTC_FULLRST);
-
-            while (1)
-                ;
+            pi_reset();
         }
     }
     
@@ -2251,23 +2261,7 @@ void ps_housekeeper()
             if ((pin & (1 << PIN_KBRESET)) == 0 && ignore_reset == 0)
             {
                 kprintf("[HKEEP] Houskeeper will reset RasPi now...\n");
-
-                ps_set_control(CONTROL_REQ_BM);
-                usleep(100000);
-
-                ps_set_control(CONTROL_DRIVE_RESET);
-                usleep(150000);
-
-                unsigned int r;
-                // trigger a restart by instructing the GPU to boot from partition 0
-                r = LE32(*PM_RSTS);
-                r &= ~0xfffffaaa;
-                *PM_RSTS = LE32(PM_WDOG_MAGIC | r); // boot from partition 0
-                *PM_WDOG = LE32(PM_WDOG_MAGIC | 10);
-                *PM_RSTC = LE32(PM_WDOG_MAGIC | PM_RSTC_FULLRST);
-
-                while (1)
-                    ;
+                pi_reset();
             }
 
             /*
@@ -2282,6 +2276,9 @@ void ps_housekeeper()
 /* Send reset from Emu68 to the mainbard. Set a flag to let housekeeper ignore it */
 void ps_send_reset()
 {
+    if(gic_available())
+        gic_local_disable();
+
     ignore_reset = 1;
 
     kprintf("[PS] CPU sending RESET\n");

--- a/src/raspi/start_rpi64.c
+++ b/src/raspi/start_rpi64.c
@@ -279,60 +279,186 @@ uintptr_t top_of_ram;
 extern int block_c0;
 #endif
 
+// Helper function to map peripheral ranges
+void map_peripheral_ranges(char *node_name, uint32_t *start_map)
+{
+    of_node_t *e = dt_find_node(node_name);
+    if (!e)
+        return;
+
+    of_property_t *p = dt_find_property(e, "ranges");
+    if (!p)
+        return;
+
+    uint32_t *ranges = p->op_value;
+    int32_t len = p->op_length;
+
+    int addr_cpu_len = dt_get_property_value_u32(e->on_parent, "#address-cells", 1, FALSE);
+    int addr_bus_len = dt_get_property_value_u32(e, "#address-cells", 1, TRUE);
+    int size_bus_len = dt_get_property_value_u32(e, "#size-cells", 1, TRUE);
+
+    int pos_abus = addr_bus_len - 1;
+    int pos_acpu = pos_abus + addr_cpu_len;
+    int pos_sbus = pos_acpu + size_bus_len;
+
+    while (len > 0)
+    {
+        uint32_t addr_bus, addr_cpu;
+        uint32_t addr_len;
+
+        addr_bus = BE32(ranges[pos_abus]);
+        addr_cpu = BE32(ranges[pos_acpu]);
+        addr_len = BE32(ranges[pos_sbus]);
+
+        /* Ignore large identity mappings in /scb branch */
+        if(addr_bus == addr_cpu)
+        {
+            len -= sizeof(int32_t) * (addr_bus_len + addr_cpu_len + size_bus_len);
+            ranges += addr_bus_len + addr_cpu_len + size_bus_len;
+            continue;
+        }
+
+        mmu_map(addr_cpu, *start_map << 21, addr_len,
+                MMU_ACCESS | MMU_ALLOW_EL0 | MMU_ATTR_DEVICE, 0);
+
+        kprintf("bus: %08x, cpu: %08x, len: %08x\n", addr_bus, addr_cpu, addr_len);
+
+        ranges[pos_acpu] = BE32(*start_map << 21);
+
+        if (addr_bus == 0x40000000) {
+            extern uintptr_t local_intc_base;
+            local_intc_base = *start_map << 21;
+        }
+
+        *start_map += addr_len >> 21;
+
+        len -= sizeof(int32_t) * (addr_bus_len + addr_cpu_len + size_bus_len);
+        ranges += addr_bus_len + addr_cpu_len + size_bus_len;
+    }
+}
+
+/* Helper to clamp and map PCIe MMIO window and publish DT properties */
+static void map_pcie_mmio_window(uint32_t *start_map)
+{
+    /* Resolve PCIe node via alias pcie0 */
+    of_node_t *pcie = NULL;
+    of_node_t *aliases = dt_find_node("/aliases");
+    if (aliases)
+    {
+        of_property_t *ap = dt_find_property(aliases, "pcie0");
+        if (ap && ap->op_value && ap->op_length > 0)
+        {
+            pcie = dt_find_node((char *)ap->op_value);
+        }
+    }
+
+    if (!pcie)
+    {
+        kprintf("[PCIE] No PCIe node, skipping\n");
+        return;
+    }
+
+    of_property_t *rp = dt_find_property(pcie, "ranges");
+    if (!rp)
+    {
+        kprintf("[PCIE] FATAL: Unable to find PCIe ranges property\n");
+        return;
+    }
+
+    uint32_t *ranges = (uint32_t *)rp->op_value;
+    int len = rp->op_length;
+
+    int addr_cpu_len = dt_get_property_value_u32(pcie->on_parent, "#address-cells", 2, FALSE);
+    int addr_bus_len = dt_get_property_value_u32(pcie, "#address-cells", 3, TRUE);
+    int size_bus_len = dt_get_property_value_u32(pcie, "#size-cells", 2, TRUE);
+
+    while (len > 0)
+    {
+        /* Decode the child (PCI) address space code from the first cell */
+        uint32_t space_code = BE32(ranges[0]);
+        int is_mem32 = ((space_code & 0x03000000u) == 0x02000000u);
+        int is_prefetch = ((space_code & 0x40000000u) != 0);
+        kprintf("[PCIE] space_code=%08x mem32=%d prefetch=%d\n", space_code, is_mem32, is_prefetch);
+
+        if (is_mem32 && !is_prefetch)
+        {
+            uint64_t phys;
+            if (addr_cpu_len >= 2)
+            {
+                phys = BE32(ranges[addr_bus_len + addr_cpu_len - 2]);
+                phys = (phys << 32) | BE32(ranges[addr_bus_len + addr_cpu_len - 1]);
+            } else if (addr_cpu_len == 1) {
+                phys = BE32(ranges[addr_bus_len + addr_cpu_len - 1]);
+            } else {
+                kprintf("[PCIE] Unsupported addr_cpu_len %d in PCIe ranges\n", addr_cpu_len);
+                break;
+            }
+
+            /* Clamp size to 64 MiB */
+            const uint32_t map_size = 0x04000000u;
+            if (size_bus_len >= 2) {
+                ranges[addr_bus_len + addr_cpu_len + size_bus_len - 2] = 0;
+            }
+            ranges[addr_bus_len + addr_cpu_len + size_bus_len - 1] = BE32(map_size);
+
+            /* Map into low virtual 0xF2xxxxxx area */
+            if (*start_map + (map_size >> 21) >= 0x1000 / 2)
+            {
+                kprintf("[PCIE] FATAL: Out of low-virt address space for PCIe MMIO!\n");
+                break;
+            }
+
+            uintptr_t virt = (uintptr_t)(*start_map << 21);
+            *start_map += map_size >> 21;
+            kprintf("[PCIE] Next low-virt addr: %08x\n", (*start_map) << 21);
+
+            mmu_map(phys, virt, (uintptr_t)map_size,
+                    MMU_ACCESS | MMU_OSHARE | MMU_ALLOW_EL0 | MMU_ATTR_DEVICE, 0);
+
+            kprintf("[PCIE] MMIO: phys=%08x%08x virt=%08x size=%08x\n",
+                    (uint32_t)(phys >> 32), (uint32_t)phys, (uint32_t)virt, (uint32_t)map_size);
+
+            /* Expose phys/virt/size as emu68-specific properties for the guest */
+            uint32_t buf64[2];
+            buf64[0] = BE32((uint32_t)(phys >> 32));
+            buf64[1] = BE32((uint32_t)(phys & 0xffffffffu));
+            dt_add_property(pcie, "emu68,pci-mmio-phys", buf64, sizeof(buf64));
+
+            buf64[0] = BE32(virt);
+            dt_add_property(pcie, "emu68,pci-mmio-virt", buf64, sizeof(buf64[0]));
+
+            buf64[0] = BE32(map_size);
+            dt_add_property(pcie, "emu68,pci-mmio-size", buf64, sizeof(buf64[0]));
+
+            /* Only adjust/map the first non-prefetchable mem32 window */
+            break;
+        }
+
+        len -= sizeof(int32_t) * (addr_bus_len + addr_cpu_len + size_bus_len);
+        ranges += addr_bus_len + addr_cpu_len + size_bus_len;
+    }
+}
+
 void platform_init()
 {
-    of_node_t *e = NULL;
+    uint32_t start_map = 0xf20 / 2;
 
     /*
         Prepare mapping for peripherals. Use and update the data from device tree here
         All peripherals are mapped in the lower 4G address space so that they can be
         accessed from m68k.
     */
-    e = dt_find_node("/soc");
-    if (e)
-    {
-        of_property_t *p = dt_find_property(e, "ranges");
-        uint32_t *ranges = p->op_value;
-        int32_t len = p->op_length;
-        uint32_t start_map = 0xf20 / 2;
+    map_peripheral_ranges("/soc", &start_map);
+    map_peripheral_ranges("/scb", &start_map);
 
-        int addr_cpu_len = dt_get_property_value_u32(e->on_parent, "#address-cells", 1, FALSE);
-        int addr_bus_len = dt_get_property_value_u32(e, "#address-cells", 1, TRUE);
-        int size_bus_len = dt_get_property_value_u32(e, "#size-cells", 1, TRUE);
-
-        int pos_abus = addr_bus_len - 1;
-        int pos_acpu = pos_abus + addr_cpu_len;
-        int pos_sbus = pos_acpu + size_bus_len;
-
-        while (len > 0)
-        {
-            uint32_t addr_bus, addr_cpu;
-            uint32_t addr_len;
-
-            addr_bus = BE32(ranges[pos_abus]);
-            addr_cpu = BE32(ranges[pos_acpu]);
-            addr_len = BE32(ranges[pos_sbus]);
-
-            (void)addr_bus;
-
-            mmu_map(addr_cpu, start_map << 21, addr_len, 
-                MMU_ACCESS | MMU_ALLOW_EL0 | MMU_ATTR_DEVICE, 0);
-
-            kprintf("bus: %08x, cpu: %08x, len: %08x\n", addr_bus, addr_cpu, addr_len);
-
-            ranges[pos_acpu] = BE32(start_map << 21);
-
-            if (addr_bus == 0x40000000) {
-                extern uintptr_t local_intc_base;
-                local_intc_base = start_map << 21;
-            }
-
-            start_map += addr_len >> 21;
-
-            len -= sizeof(int32_t) * (addr_bus_len + addr_cpu_len + size_bus_len);
-            ranges += addr_bus_len + addr_cpu_len + size_bus_len;
-        }
-    }
+    /* 
+        Map PCIe MMIO window if PCIe is present.
+        Reduces the window size to 64 MiB to fit into the low-virt area.
+        Exposes the phys/virt/size as emu68,pci-mmio-phys/virt/size properties.
+        The mapping in ranges remains using physical address.
+        The PCIe driver needs both the physical and virtual address.
+    */
+    map_pcie_mmio_window(&start_map);
 }
 
 void platform_post_init()


### PR DESCRIPTION
This enables PCIe controller support:

- Enables 36-bit IPS on MMU; this is because the BAR window is mapped at phys address 0x600000000, so without this change the MMU page faults with DFSC=0x2 (Address size fault at level 2)
- Maps the /scb ranges in a similar fashion to how /soc was already mapped. This results with the same phys address range being mapped twice into 0xf2 area, but is cleaner - i.e. the genet driver will also be able to map genet regs via /scb tree as per spec (it currently needs to "jump" to /soc to find the mapping)
- Clamps the PCIe MMIO (BAR) to 64MiB (it is 1GiB in the devtree)
- Maps the PCIe MMIO (BAR) window into the 0xF2 area
- There's also a change in dt_find_node which enables it to find 2nd level nodes - this is used to find the PCIe node at SCB
- There are also extra properties added to the device tree, because the PCIe driver needs both the physical and virtual addresses of the MMIO window in order to set up the controller

Note: Not tested on PI3, I am not sure if the IPS change is OK for PI3. The PCIe stuff should skip once it doesn't find a PCIe node in the devtree.