### PR TITLE
1 1 wip

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14.0)
 project(Emu68 VERSION 1.1.0)
-set(PROJECT_VERSION 1.1.0-alpha.2)
+set(PROJECT_VERSION 1.1.0-beta.1)
 
 #set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
 include(ExternalProject)

--- a/src/M68k_LINEF.c
+++ b/src/M68k_LINEF.c
@@ -770,9 +770,9 @@ void FPU_FetchData(struct TranslatorContext *ctx, uint8_t *reg, uint16_t opcode,
                     } ud;
                     ud.i = (uint64_t)cache_read_64(ICACHE, (uintptr_t)&ctx->tc_M68kCodePtr[1]);
                     /* Check if immediate constant is possible */
-                    if ((ud.i & 0xffffffffffULL) == 0 && 
-                            ((ud.i & 0x7fc0000000000000ULL) == 0x4000000000000000ULL || 
-                             (ud.i & 0x7fc0000000000000ULL) == 0x3fc0000000000000ULL)) {
+                    if ((ud.i & 0x0000ffffffffffffULL) == 0 && 
+                       ((ud.i & 0x7fc0000000000000ULL) == 0x4000000000000000ULL || 
+                        (ud.i & 0x7fc0000000000000ULL) == 0x3fc0000000000000ULL)) {
                         uint8_t imm = (ud.i >> 48) & 0x7f;
                         if (ud.i & 0x8000000000000000ULL) imm |= 0x80;
                         EMIT(ctx, fmov(*reg, imm));


### PR DESCRIPTION
Fixed the Heisenbug - the more I was looking at, the less it was visible. Check algorithm for FPU load immediate on aarch64 was wrong for double type. It created immediate loads with rounding errors what led to small up to severe issues with executed 68k code.